### PR TITLE
Fix links

### DIFF
--- a/src/adventures-in-devops/devops-014-continuous-delivery-with-julian-fahrer.md
+++ b/src/adventures-in-devops/devops-014-continuous-delivery-with-julian-fahrer.md
@@ -79,9 +79,9 @@ They share how the current development culture is to give the QA team enough tim
 
 
 
-*   [Hover](hover.to)
+*   [Hover](https://hover.to)
 *   [Launch Darkly](https://launchdarkly.com/)
-*   [Split.io](split.io)
+*   [Split.io](https://split.io)
 *   [Codefresh.io](https://codefresh.io/)
 *   [Argo CD](https://argoproj.github.io/argo-cd/)
 *   [Flux](https://fluxcd.io/)
@@ -121,4 +121,4 @@ They share how the current development culture is to give the QA team enough tim
 
 *   [Accelerate](https://amzn.to/33iuceU)
 *   [The State of DevOps](https://puppet.com/resources/whitepaper/state-of-devops-report)
-*   [Walk in Balance](walkinbalance.net)
+*   [Walk in Balance](https://walkinbalance.net)


### PR DESCRIPTION
The schema was missing so it would link to `https://devchat.tv/adventures-in-devops/devops-014-continuous-delivery-with-julian-fahrer/hover.to` instead of `hover.to`